### PR TITLE
Doc-fix: Note about Color::Normal not resetting the terminal color to…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,9 @@ pub trait ToStyle : Sized {
 /// `ToStyle`'s methods directly on a `Color` variant like:
 ///
 /// `println!("{}", Color::Red.bold().paint("Red and bold"));`
+///
+/// Note: Using `Color::Normal` will *not* reset the color to the default
+/// terminal color.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Color {
     Normal,


### PR DESCRIPTION
… default (see #2)
