### PR TITLE
Builds with term v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT"
 keywords = ["terminal", "color", "format", "paint"]
 
 [dependencies]
-term = "*"
+term = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,7 +451,7 @@ impl Style {
         macro_rules! try_term {
             ($e:expr) => ({
                 match $e {
-                    Ok(true) => {},
+                    Ok(()) => {},
                     _ => { return Err(Error); },
                 }
             })


### PR DESCRIPTION
Hello,

Your library didn't build with the latest version of the `term` crate. I fixed that and I removed the wildcard from the `Cargo.toml` file.
